### PR TITLE
Pluralize "Data Structures" category in cabal file

### DIFF
--- a/treap.cabal
+++ b/treap.cabal
@@ -12,7 +12,7 @@ license-file:        LICENSE
 author:              Dmitrii Kovanikov
 maintainer:          kovanikov@gmail.com
 copyright:           2019 Dmitrii Kovanikov
-category:            Data Structure, Tree
+category:            Data Structures, Tree
 build-type:          Simple
 extra-doc-files:     README.md
                      CHANGELOG.md


### PR DESCRIPTION
Hi, I was just browsing Hackage and noticed that there is a [Data Structure](https://hackage.haskell.org/packages/#cat:Data%20Structure) (singular) category and a "Data Structures" (plural) category. The latter seems much more widely used. Just in the interest of cleaning things up aesthetically, I was wondering if it wouldn't be too much of a bother to accept and release this to help make the Hackage category list a little nicer? Thank you :smiley_cat: 